### PR TITLE
Hanacloud setting

### DIFF
--- a/src/main/java/org/sap/cytoscape/internal/hdb/HanaConnectionCredentials.java
+++ b/src/main/java/org/sap/cytoscape/internal/hdb/HanaConnectionCredentials.java
@@ -18,20 +18,6 @@ public class HanaConnectionCredentials extends AbstractConnectionCredentials {
     /**
      * Construct database connection credentials
      *
-     * @param host  Hostname
-     * @param port  Port
-     * @param username  Database User
-     * @param password  Database User Password
-     * @param advancedProperties Advanced JDBC Properties
-     * @param proxyConnectionCredentials    Proxy details. Leave NULL if no proxy used.
-     */
-    public HanaConnectionCredentials(String host, String port, String username, String password, String advancedProperties, ProxyConnectionCredentials proxyConnectionCredentials) {
-        this(host, port, username, password, false, advancedProperties, proxyConnectionCredentials);
-    }
-
-    /**
-     * Construct database connection credentials
-     *
      * @param host                       Hostname
      * @param port                       Port
      * @param username                   Database User

--- a/src/main/java/org/sap/cytoscape/internal/hdb/HanaConnectionCredentials.java
+++ b/src/main/java/org/sap/cytoscape/internal/hdb/HanaConnectionCredentials.java
@@ -11,6 +11,8 @@ public class HanaConnectionCredentials extends AbstractConnectionCredentials {
 
     public String advancedProperties;
 
+    public boolean isHanaCloud;
+
     public ProxyConnectionCredentials proxyConnectionCredentials;
 
     /**
@@ -24,7 +26,27 @@ public class HanaConnectionCredentials extends AbstractConnectionCredentials {
      * @param proxyConnectionCredentials    Proxy details. Leave NULL if no proxy used.
      */
     public HanaConnectionCredentials(String host, String port, String username, String password, String advancedProperties, ProxyConnectionCredentials proxyConnectionCredentials) {
+        this(host, port, username, password, false, advancedProperties, proxyConnectionCredentials);
+    }
+
+    /**
+     * Construct database connection credentials
+     *
+     * @param host                       Hostname
+     * @param port                       Port
+     * @param username                   Database User
+     * @param password                   Database User Password
+     * @param isHanaCloud                If set to true the HANA instance is
+     *                                   considered to be a HANA Cloud instance, if
+     *                                   false it will be determined during
+     *                                   connection.
+     * @param advancedProperties         Advanced JDBC Properties
+     * @param proxyConnectionCredentials Proxy details. Leave NULL if no proxy used.
+     */
+    public HanaConnectionCredentials(String host, String port, String username, String password, boolean isHanaCloud,
+            String advancedProperties, ProxyConnectionCredentials proxyConnectionCredentials) {
         super(host, port, username, password);
+        this.isHanaCloud = isHanaCloud;
         this.advancedProperties = advancedProperties;
         this.proxyConnectionCredentials = proxyConnectionCredentials;
     }

--- a/src/main/java/org/sap/cytoscape/internal/tasks/CyConnectTaskTunables.java
+++ b/src/main/java/org/sap/cytoscape/internal/tasks/CyConnectTaskTunables.java
@@ -13,6 +13,11 @@ import java.util.Properties;
 public class CyConnectTaskTunables {
     /**
      *
+     */
+    private static final String KEY_HDB_ISHANACLOUD = "hdb.ishanacloud";
+
+    /**
+     *
      * @return Title of the input parameter dialog
      */
     @ProvidesTitle
@@ -29,6 +34,14 @@ public class CyConnectTaskTunables {
      */
     @Tunable(description="Port", groups={"SAP HANA Database"}, required = true, gravity = 20)
     public String port;
+
+    /**
+     * Determines if the HANA instance is to be considere a HANA Cloud (regardless
+     * of the content of the build_branch value that the host returns)
+     */
+    @Tunable(description = "Hana Cloud", groups = {
+            "SAP HANA Database" }, gravity = 24, tooltip = "If not checked there will be an automatic check whether it's a HANA Cloud or HANA On-prem.")
+    public boolean isHanaCloud = false;
 
     /**
      * Specifies advanced option to pass as part of the connection string. This is supposed
@@ -110,6 +123,7 @@ public class CyConnectTaskTunables {
             this.advancedProperties = props.getProperty("hdb.advancedproperties");
             this.username = props.getProperty("hdb.username");
             this.password = props.getProperty("hdb.password");
+            this.isHanaCloud = Boolean.parseBoolean(props.getProperty(KEY_HDB_ISHANACLOUD, "false"));
 
             this.enableProxyConfiguration = Boolean.parseBoolean(props.getProperty("hdb.proxy.enabled", "false"));
             if(props.getProperty("hdb.proxy.type") != null){
@@ -152,6 +166,7 @@ public class CyConnectTaskTunables {
                 this.port,
                 this.username,
                 this.password,
+                this.isHanaCloud,
                 this.advancedProperties,
                 proxyConnectionCredentials
         );
@@ -168,6 +183,7 @@ public class CyConnectTaskTunables {
         credProps.setProperty("hdb.advancedproperties", this.advancedProperties);
         credProps.setProperty("hdb.port", this.port);
         credProps.setProperty("hdb.username", this.username);
+        credProps.setProperty(KEY_HDB_ISHANACLOUD, String.valueOf(this.isHanaCloud));
 
         credProps.setProperty("hdb.proxy.enabled", String.valueOf(this.enableProxyConfiguration));
         credProps.setProperty("hdb.proxy.type", this.proxyType.getSelectedValue());

--- a/src/test/java/HanaConnectionCredentialsTest.java
+++ b/src/test/java/HanaConnectionCredentialsTest.java
@@ -11,7 +11,7 @@ public class HanaConnectionCredentialsTest {
 
     @Test
     public void testGenerateAdvancedProperties(){
-        HanaConnectionCredentials cred = new HanaConnectionCredentials(null, null, null, null, null, null);
+        HanaConnectionCredentials cred = new HanaConnectionCredentials(null, null, null, null, false, null, null);
         Properties props = null;
 
         try{
@@ -78,12 +78,6 @@ public class HanaConnectionCredentialsTest {
             fail();
         }
 
-    }
-
-    @Test
-    public void testHanaCloudPropertyDefaultValue() {
-        HanaConnectionCredentials cred = new HanaConnectionCredentials(null, null, null, null, null, null);
-        Assert.assertFalse(cred.isHanaCloud);
     }
 
     @Test

--- a/src/test/java/HanaConnectionCredentialsTest.java
+++ b/src/test/java/HanaConnectionCredentialsTest.java
@@ -80,4 +80,15 @@ public class HanaConnectionCredentialsTest {
 
     }
 
+    @Test
+    public void testHanaCloudPropertyDefaultValue() {
+        HanaConnectionCredentials cred = new HanaConnectionCredentials(null, null, null, null, null, null);
+        Assert.assertFalse(cred.isHanaCloud);
+    }
+
+    @Test
+    public void testHanaCloudPropertyInConstructor() {
+        HanaConnectionCredentials cred = new HanaConnectionCredentials(null, null, null, null, true, null, null);
+        Assert.assertTrue(cred.isHanaCloud);
+    }
 }

--- a/src/test/java/HanaConnectionManagerTest.java
+++ b/src/test/java/HanaConnectionManagerTest.java
@@ -26,6 +26,7 @@ public class HanaConnectionManagerTest {
                     connectProps.getProperty("port"),
                     connectProps.getProperty("username"),
                     connectProps.getProperty("password"),
+                    Boolean.valueOf(connectProps.getProperty("isHanaCloud", "false")),
                     null,
                     null
             );

--- a/src/test/resources/testcredentials.properties.template
+++ b/src/test/resources/testcredentials.properties.template
@@ -2,3 +2,4 @@ host=
 port=
 username=
 password=
+isHanaCloud=


### PR DESCRIPTION
Add new connection parameter for HANA Cloud

With this new parameter you can override the automatic detection of
whether you are connecting to a HANA Cloud or On-prem host. This
addresses the issue that in some cases the 'build_branch' value that is
returned by the HANA is empty and thus the On-prem SQL is used against
a HANA Cloud.